### PR TITLE
Add the --no-iri flag to wget-at arguments.

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -180,6 +180,7 @@ class WgetArgs(object):
             '-e', 'robots=off',
             '--rotate-dns',
             '--recursive', '--level=inf',
+            '--no-iri',
             '--no-parent',
             '--page-requisites',
             '--timeout', '30',

--- a/pipeline.py
+++ b/pipeline.py
@@ -54,7 +54,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20210501.09'
+VERSION = '20210501.10'
 USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36'
 TRACKER_ID = 'bintray'
 TRACKER_HOST = 'legacy-api.arpa.li'


### PR DESCRIPTION
When downloading repository files, bintray redirects us to one of
serveral CDNs.
One of which is cloudfront.
If a file has a ~ in its name, like https://dl.bintray.com/lamyj/generic/apt/pool/main/o/odil/python3-odil_0.12.1-1~stretch_amd64.deb, then the url in the Location header from bintray will be to cloudfront with %7E in it (url escaped version of ~).
wget-at will then modify the url in the location header and unencode the %7E before making a request to cloudfront.
Cloudfront does not consider the file with the ~ in it to be equal to the escaped %7E version.
As such we need to disable this unescaping behaviour.
The --no-iri flag seems, from my testing, to disable this behaviour and allows the file to download correctly.